### PR TITLE
install_ubuntu_python: Upgrade to tensorflow-gpu==2.4.1

### DIFF
--- a/install_python_ubuntu.sh
+++ b/install_python_ubuntu.sh
@@ -12,7 +12,7 @@ set -uexo pipefail
 
 echo "Installing Python libraries..."
 conda install ipython
-conda install tensorflow-gpu==2.2
+conda install tensorflow-gpu==2.4.1
 
 pip install pybullet==3.0.4
 pip install packaging==19.2
@@ -24,7 +24,7 @@ pip install scikit-image==0.17.2
 pip install gputil==1.4.0
 pip install circle-fit==0.1.3
 
-pip install tensorflow-addons==0.11.1
+pip install tensorflow-addons==0.13.0
 pip install tensorflow_hub==0.8.0
 
 pip install -e .


### PR DESCRIPTION
* Fixes error, `No module named 'tensorflow.python.types'`
* Upgrade to tensorflow-addons==0.13.0, per console warnings when using
  tensorflow-addons==0.11.0 with tensorflow-gpu==2.4.1

Resolves #4 per @PeterQiu0516's suggestion - thanks!

@DanielTakeshi Any chance you think this is a good fix?

This allows me to run the following two sample commands:
```sh
python main.py --gpu=0 --agent=dummy --hz=240 --task=cable-shape --disp
python main.py --gpu=0 --agent=dummy --hz=480 --task=bag-items-easy --disp
```